### PR TITLE
Add AsyncMessageApiClient with httpx support

### DIFF
--- a/feishu_sdk/__init__.py
+++ b/feishu_sdk/__init__.py
@@ -4,7 +4,7 @@ Feishu/Lark Bot SDK
 A simple Python SDK for building Feishu/Lark bots with messaging capabilities.
 """
 
-from .api import LarkException, MessageApiClient
+from .api import AsyncMessageApiClient, LarkException, MessageApiClient
 from .event import Event, InvalidEventException
 from .utils import dict_2_obj
 from .webhook import WebhookHandler, create_webhook_handler
@@ -12,6 +12,7 @@ from .webhook import WebhookHandler, create_webhook_handler
 __version__ = "0.1.0"
 __all__ = [
     "MessageApiClient",
+    "AsyncMessageApiClient",
     "LarkException",
     "Event",
     "InvalidEventException",

--- a/feishu_sdk/api.py
+++ b/feishu_sdk/api.py
@@ -4,6 +4,13 @@ from typing import Optional
 
 import requests
 
+try:
+    import httpx
+
+    HTTPX_AVAILABLE = True
+except ImportError:
+    HTTPX_AVAILABLE = False
+
 # const
 TENANT_ACCESS_TOKEN_URI = "/open-apis/auth/v3/tenant_access_token/internal"
 MESSAGE_URI = "/open-apis/im/v1/messages"
@@ -105,3 +112,115 @@ class LarkException(Exception):
         return "{}:{}".format(self.code, self.msg)
 
     __repr__ = __str__
+
+
+class AsyncMessageApiClient:
+    """Async version of MessageApiClient using httpx for non-blocking HTTP calls."""
+
+    def __init__(self, app_id: str, app_secret: str, lark_host: str):
+        if not HTTPX_AVAILABLE:
+            raise ImportError(
+                "httpx is required for AsyncMessageApiClient. "
+                "Install it with: pip install feishu-bot-sdk[async]"
+            )
+        self._app_id = app_id
+        self._app_secret = app_secret
+        self._lark_host = lark_host
+        self._tenant_access_token = ""
+        self._client: Optional["httpx.AsyncClient"] = None
+
+    @classmethod
+    def from_env(
+        cls, lark_host: str, app_id_env: str = "APP_ID", app_secret_env: str = "APP_SECRET"
+    ):
+        """Create client from environment variables"""
+        app_id = os.getenv(app_id_env)
+        app_secret = os.getenv(app_secret_env)
+        if not app_id or not app_secret:
+            raise ValueError(f"Environment variables {app_id_env} and {app_secret_env} must be set")
+        return cls(app_id, app_secret, lark_host)
+
+    async def __aenter__(self) -> "AsyncMessageApiClient":
+        """Async context manager entry."""
+        self._client = httpx.AsyncClient()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Async context manager exit."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+    @property
+    def tenant_access_token(self):
+        return self._tenant_access_token
+
+    async def send_text_with_open_id(self, open_id: str, content: str):
+        """Send a text message to a user by open_id."""
+        return await self.send("open_id", open_id, "text", content)
+
+    async def send_card_with_open_id(self, open_id: str, content: str):
+        """Send an interactive card to a user by open_id."""
+        return await self.send("open_id", open_id, "interactive", content)
+
+    async def send_update_message_card(self, message_id: str, updated_card: str):
+        """Update a message card that was sent previously."""
+        await self._authorize_tenant_access_token()
+        url = "{}{}/{}".format(self._lark_host, MESSAGE_URI, message_id)
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + self.tenant_access_token,
+        }
+        req_body = {"content": updated_card}
+        print("update message card url: ", url)
+        print("update message card headers: ", headers)
+        print("update message card body: ", req_body)
+        resp = await self._request("PATCH", url, headers=headers, json=req_body)
+        self._check_error_response(resp)
+
+    async def send(self, receive_id_type: str, receive_id: str, msg_type: str, content: str):
+        """Send message to user, implemented based on Feishu open api capability."""
+        await self._authorize_tenant_access_token()
+        url = "{}{}?receive_id_type={}".format(self._lark_host, MESSAGE_URI, receive_id_type)
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + self.tenant_access_token,
+        }
+        req_body = {
+            "receive_id": receive_id,
+            "content": content,
+            "msg_type": msg_type,
+        }
+        resp = await self._request("POST", url, headers=headers, json=req_body)
+        print(resp)
+        self._check_error_response(resp)
+        return resp.json()["data"]["message_id"]
+
+    async def _authorize_tenant_access_token(self):
+        """Get tenant_access_token and set it."""
+        url = "{}{}".format(self._lark_host, TENANT_ACCESS_TOKEN_URI)
+        req_body = {"app_id": self._app_id, "app_secret": self._app_secret}
+        print("Authorize tenant_access_token:\n", req_body)
+        response = await self._request("POST", url, data=req_body)
+        self._check_error_response(response)
+        self._tenant_access_token = response.json().get("tenant_access_token")
+
+    async def _request(self, method: str, url: str, **kwargs) -> "httpx.Response":
+        """Make an HTTP request using the async client."""
+        if self._client:
+            return await self._client.request(method, url, **kwargs)
+        else:
+            # If not using context manager, create a temporary client
+            async with httpx.AsyncClient() as client:
+                return await client.request(method, url, **kwargs)
+
+    @staticmethod
+    def _check_error_response(resp: "httpx.Response"):
+        """Check if the response contains error information."""
+        if resp.status_code != 200:
+            resp.raise_for_status()
+        response_dict = resp.json()
+        code = response_dict.get("code", -1)
+        if code != 0:
+            logging.error(response_dict)
+            raise LarkException(code=code, msg=response_dict.get("msg"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+async = [
+    "httpx>=0.25.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.21.0",
     "responses>=0.23.0",
+    "respx>=0.20.0",
+    "httpx>=0.25.0",
     "black>=23.0.0",
     "isort>=5.12.0",
     "mypy>=1.0.0",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,10 +2,12 @@
 
 import os
 
+import httpx
 import pytest
 import responses
+import respx
 
-from feishu_sdk.api import LarkException, MessageApiClient
+from feishu_sdk.api import AsyncMessageApiClient, LarkException, MessageApiClient
 
 
 class TestMessageApiClient:
@@ -215,3 +217,189 @@ class TestLarkException:
         """Test repr is same as str."""
         exc = LarkException(code=789, msg="test")
         assert repr(exc) == str(exc)
+
+
+class TestAsyncMessageApiClient:
+    """Tests for the AsyncMessageApiClient class."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a test client."""
+        return AsyncMessageApiClient(
+            app_id="test_app_id", app_secret="test_app_secret", lark_host="https://open.feishu.cn"
+        )
+
+    def test_init(self, client):
+        """Test client initialization."""
+        assert client._app_id == "test_app_id"
+        assert client._app_secret == "test_app_secret"
+        assert client._lark_host == "https://open.feishu.cn"
+        assert client._tenant_access_token == ""
+        assert client._client is None
+
+    def test_tenant_access_token_property(self, client):
+        """Test tenant_access_token property."""
+        client._tenant_access_token = "test_token"
+        assert client.tenant_access_token == "test_token"
+
+    def test_from_env_success(self, monkeypatch):
+        """Test creating client from environment variables."""
+        monkeypatch.setenv("APP_ID", "env_app_id")
+        monkeypatch.setenv("APP_SECRET", "env_app_secret")
+
+        client = AsyncMessageApiClient.from_env("https://open.feishu.cn")
+        assert client._app_id == "env_app_id"
+        assert client._app_secret == "env_app_secret"
+
+    def test_from_env_custom_vars(self, monkeypatch):
+        """Test from_env with custom variable names."""
+        monkeypatch.setenv("MY_APP_ID", "custom_id")
+        monkeypatch.setenv("MY_APP_SECRET", "custom_secret")
+
+        client = AsyncMessageApiClient.from_env(
+            "https://open.feishu.cn", app_id_env="MY_APP_ID", app_secret_env="MY_APP_SECRET"
+        )
+        assert client._app_id == "custom_id"
+        assert client._app_secret == "custom_secret"
+
+    def test_from_env_missing_app_id(self, monkeypatch):
+        """Test from_env raises error when APP_ID is missing."""
+        monkeypatch.delenv("APP_ID", raising=False)
+        monkeypatch.setenv("APP_SECRET", "secret")
+
+        with pytest.raises(ValueError) as exc_info:
+            AsyncMessageApiClient.from_env("https://open.feishu.cn")
+        assert "APP_ID" in str(exc_info.value)
+
+    def test_from_env_missing_app_secret(self, monkeypatch):
+        """Test from_env raises error when APP_SECRET is missing."""
+        monkeypatch.setenv("APP_ID", "id")
+        monkeypatch.delenv("APP_SECRET", raising=False)
+
+        with pytest.raises(ValueError) as exc_info:
+            AsyncMessageApiClient.from_env("https://open.feishu.cn")
+        assert "APP_SECRET" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self, client):
+        """Test async context manager entry and exit."""
+        assert client._client is None
+
+        async with client:
+            assert client._client is not None
+            assert isinstance(client._client, httpx.AsyncClient)
+
+        assert client._client is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_authorize_tenant_access_token(self, client):
+        """Test tenant access token authorization."""
+        respx.post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal").mock(
+            return_value=httpx.Response(200, json={"code": 0, "tenant_access_token": "new_token"})
+        )
+
+        async with client:
+            await client._authorize_tenant_access_token()
+            assert client._tenant_access_token == "new_token"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_authorize_tenant_access_token_error(self, client):
+        """Test tenant access token authorization with API error."""
+        respx.post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal").mock(
+            return_value=httpx.Response(200, json={"code": 99991, "msg": "invalid app_id"})
+        )
+
+        async with client:
+            with pytest.raises(LarkException) as exc_info:
+                await client._authorize_tenant_access_token()
+            assert exc_info.value.code == 99991
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_send_text_with_open_id(self, client):
+        """Test sending text message."""
+        # Mock token endpoint
+        respx.post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal").mock(
+            return_value=httpx.Response(200, json={"code": 0, "tenant_access_token": "test_token"})
+        )
+        # Mock message endpoint
+        respx.post(url__regex=r".*/open-apis/im/v1/messages\?.*").mock(
+            return_value=httpx.Response(200, json={"code": 0, "data": {"message_id": "msg_123"}})
+        )
+
+        async with client:
+            result = await client.send_text_with_open_id("ou_123", "Hello World")
+            assert result == "msg_123"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_send_card_with_open_id(self, client):
+        """Test sending card message."""
+        respx.post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal").mock(
+            return_value=httpx.Response(200, json={"code": 0, "tenant_access_token": "test_token"})
+        )
+        respx.post(url__regex=r".*/open-apis/im/v1/messages\?.*").mock(
+            return_value=httpx.Response(200, json={"code": 0, "data": {"message_id": "msg_456"}})
+        )
+
+        async with client:
+            card_content = '{"elements": []}'
+            result = await client.send_card_with_open_id("ou_123", card_content)
+            assert result == "msg_456"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_send_update_message_card(self, client):
+        """Test updating a message card."""
+        respx.post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal").mock(
+            return_value=httpx.Response(200, json={"code": 0, "tenant_access_token": "test_token"})
+        )
+        respx.patch("https://open.feishu.cn/open-apis/im/v1/messages/msg_123").mock(
+            return_value=httpx.Response(200, json={"code": 0})
+        )
+
+        async with client:
+            await client.send_update_message_card("msg_123", '{"elements": []}')
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_check_error_response_http_error(self, client):
+        """Test error checking with HTTP error."""
+        respx.post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal").mock(
+            return_value=httpx.Response(500, json={"error": "server error"})
+        )
+
+        async with client:
+            with pytest.raises(httpx.HTTPStatusError):
+                await client._authorize_tenant_access_token()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_check_error_response_api_error(self, client):
+        """Test error checking with API-level error."""
+        respx.post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal").mock(
+            return_value=httpx.Response(200, json={"code": 10001, "msg": "Invalid token"})
+        )
+
+        async with client:
+            with pytest.raises(LarkException) as exc_info:
+                await client._authorize_tenant_access_token()
+            assert exc_info.value.code == 10001
+            assert exc_info.value.msg == "Invalid token"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_without_context_manager(self, client):
+        """Test that client works without context manager."""
+        respx.post("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal").mock(
+            return_value=httpx.Response(200, json={"code": 0, "tenant_access_token": "test_token"})
+        )
+        respx.post(url__regex=r".*/open-apis/im/v1/messages\?.*").mock(
+            return_value=httpx.Response(200, json={"code": 0, "data": {"message_id": "msg_789"}})
+        )
+
+        # Should work without async context manager (creates temporary client)
+        result = await client.send_text_with_open_id("ou_123", "Hello")
+        assert result == "msg_789"


### PR DESCRIPTION
## Summary
- Add `AsyncMessageApiClient` class using `httpx` for non-blocking HTTP calls
- Support async context manager via `__aenter__()` and `__aexit__()`
- Include factory method `from_env()` for environment variable configuration
- Add `httpx>=0.25.0` as optional dependency under `[async]`

## Usage

```python
async with AsyncMessageApiClient.from_env() as client:
    await client.send_text_with_open_id(open_id, "Hello")
```

## Changes
- `feishu_sdk/api.py`: Add `AsyncMessageApiClient` class with all async messaging methods
- `feishu_sdk/__init__.py`: Export `AsyncMessageApiClient` 
- `pyproject.toml`: Add `httpx` as optional `[async]` dependency, add `respx` and `httpx` to dev dependencies
- `tests/test_api.py`: Add comprehensive tests for `AsyncMessageApiClient`

## Test plan
- [x] All existing tests pass (67 tests)
- [x] New async client tests cover initialization, context manager, token auth, and all messaging methods
- [x] Error handling tests for both HTTP and API errors

Closes #4